### PR TITLE
Remove unused and outdated base-api service

### DIFF
--- a/docker/docker-compose.all.yml
+++ b/docker/docker-compose.all.yml
@@ -9,15 +9,6 @@ services:
     ports:
       - '1080:1080'
       - '${MAILDEV_PORT}:1025'
-  base-api:
-    extends:
-      file: docker-compose.app.yml
-      service: base-api
-    depends_on:
-      - qdrant
-      - pgdb
-      - redis
-      - minio
 
   qdrant:
     image: qdrant/qdrant:v1.6.1


### PR DESCRIPTION
Seems like this fragment is not longer used (and also not working because `docker-compose.app.yml` doesn't exist any more)